### PR TITLE
Fix http links in citation sections

### DIFF
--- a/articles/gouvernance-communs-numeriques.html
+++ b/articles/gouvernance-communs-numeriques.html
@@ -187,7 +187,7 @@
                     <div class="citation-info">
                         <h3>Comment citer cet article :</h3>
                         <p>
-                            BERGE, A. (2025). <em>Gouverner les communs numériques : modèles, expériences et défis</em>. Blog Communs Numériques. Disponible sur : http://communs-numeriques.fr/articles/gouvernance-des-communs
+                            BERGE, A. (2025). <em>Gouverner les communs numériques : modèles, expériences et défis</em>. Blog Communs Numériques. Disponible sur : https://communs-numeriques.fr/articles/gouvernance-des-communs
                         </p>
                     </div>
 

--- a/articles/introduction-communs-numeriques.html
+++ b/articles/introduction-communs-numeriques.html
@@ -155,7 +155,7 @@
                     <div class="citation-info">
                         <h3>Comment citer cet article :</h3>
                         <p>
-                            BERGE, A. (2025). <em>Communs numériques : des origines aux enjeux d’aujourd’hui</em>. Blog Communs Numériques. Disponible sur : http://communs-numeriques.fr/articles/introduction-communs-numeriques
+                            BERGE, A. (2025). <em>Communs numériques : des origines aux enjeux d’aujourd’hui</em>. Blog Communs Numériques. Disponible sur : https://communs-numeriques.fr/articles/introduction-communs-numeriques
                         </p>
             </div>
         </section>


### PR DESCRIPTION
## Summary
- use `https://` for citation links in Introduction article
- use `https://` for citation links in Gouvernance article

## Testing
- `npm test` *(fails: could not find package.json)*