### PR TITLE
feat: Move 'About' section to a separate page

### DIFF
--- a/apropos.html
+++ b/apropos.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>À Propos - Communs Numériques</title>
+    <link rel="stylesheet" href="style.css">
+    <link rel="icon" href="images/favicon.ico" type="image/x-icon">
+    <link rel="apple-touch-icon" href="images/apple-touch-icon.png">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;900&display=swap" rel="stylesheet">
+</head>
+<body>
+    <header id="main-header">
+    <div class="container">
+        <a href="./index.html#hero" class="logo">Communs Numériques</a>
+        <nav class="main-nav">
+            <ul>
+                <li><a href="./index.html#hero">Accueil</a></li>
+                <li><a href="./apropos.html">À propos</a></li>
+                <li><a href="./index.html#publications">Publications</a></li>
+                <li><a href="./articles/memoire-institutionnalisation-communs-numeriques.html">Mémoire</a></li>
+                <li><a href="./contact.html">Contact</a></li>
+            </ul>
+        </nav>
+        <button class="nav-toggle" aria-label="Ouvrir le menu" aria-expanded="false">
+            <span class="hamburger"></span>
+        </button>
+    </div>
+</header>
+    <main>
+        <section id="about" class="animate-on-scroll fade-in">
+            <div class="container">
+                <h2 class="section-title text-center animate-on-scroll slide-in-up">
+                    À propos de l'auteur
+                </h2>
+                <div class="about-content">
+                    <div class="about-text animate-on-scroll slide-in-left">
+                        <p>Fort d'une expérience de plus de quinze ans comme manager au sein de divers organismes de Sécurité Sociale, mon parcours m'a offert une perspective unique sur les défis et les opportunités du secteur public. En 2020, j'ai pris le virage du management des systèmes d'information.</p>
+                        <p>Je suis Alexandre BERGE, passionné par l'impact de l'innovation publique et des technologies sur notre société. Ce blog est le prolongement de mon mémoire de recherche « <em><a href="articles/memoire-institutionnalisation-communs-numeriques.html">Les facteurs d'institutionnalisation des communs numériques dans l'administration</a></em> ». Que vous soyez décideur, chercheur, militant ou simple citoyen intéressé, j'espère que ces pages nourriront votre curiosité et vos propres initiatives.</p>
+                    </div>
+                    <div class="about-image-wrapper animate-on-scroll slide-in-right">
+                        <img src="images/berge-a-profil.png" alt="Portrait de A. BERGE, auteur du blog Communs Numériques" class="about-image-item" loading="lazy">
+                    </div>
+                </div>
+            </div>
+        </section>
+    </main>
+    <footer id="main-footer">
+    <div class="container">
+        <p>© <span id="current-year"></span> Alexandre BERGE. Contenu sous licence <a href="https://creativecommons.org/licenses/by-sa/4.0/deed.fr" target="_blank" rel="noopener noreferrer">CC BY-SA 4.0</a>.</p>
+        <p><a href="./mentions-legales.html">Mentions Légales</a> | <a href="./politique-confidentialite.html">Politique de confidentialité</a></p>
+    </div>
+</footer>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
         <nav class="main-nav">
             <ul>
                 <li><a href="./index.html#hero">Accueil</a></li>
-                <li><a href="./index.html#about">À propos</a></li>
+                <li><a href="./apropos.html">À propos</a></li>
                 <li><a href="./index.html#publications">Publications</a></li>
                 <li><a href="./articles/memoire-institutionnalisation-communs-numeriques.html">Mémoire</a></li>
                 <li><a href="./contact.html">Contact</a></li>
@@ -49,23 +49,6 @@
                 <h1 class="animate-on-scroll slide-in-up delay-1">Les Communs Numériques : Partager la connaissance à l’ère du digital</h1>
                 <p class="subtitle animate-on-scroll slide-in-up delay-2">Explorer les enjeux du numérique partagé.</p>
                 <a href="#publications" class="cta-button animate-on-scroll slide-in-up delay-3">Découvrir les publications</a>
-            </div>
-        </section>
-
-        <section id="about" class="animate-on-scroll fade-in">
-            <div class="container">
-                <h2 class="section-title text-center animate-on-scroll slide-in-up">
-                    À propos de l'auteur
-                </h2>
-                <div class="about-content">
-                    <div class="about-text animate-on-scroll slide-in-left">
-                        <p>Fort d'une expérience de plus de quinze ans comme manager au sein de divers organismes de Sécurité Sociale, mon parcours m'a offert une perspective unique sur les défis et les opportunités du secteur public. En 2020, j'ai pris le virage du management des systèmes d'information.</p>
-                        <p>Je suis Alexandre BERGE, passionné par l'impact de l'innovation publique et des technologies sur notre société. Ce blog est le prolongement de mon mémoire de recherche « <em><a href="articles/memoire-institutionnalisation-communs-numeriques.html">Les facteurs d'institutionnalisation des communs numériques dans l'administration</a></em> ». Que vous soyez décideur, chercheur, militant ou simple citoyen intéressé, j'espère que ces pages nourriront votre curiosité et vos propres initiatives.</p>
-                    </div>
-                    <div class="about-image-wrapper animate-on-scroll slide-in-right">
-                        <img src="images/berge-a-profil.png" alt="Portrait de A. BERGE, auteur du blog Communs Numériques" class="about-image-item" loading="lazy">
-                    </div>
-                </div>
             </div>
         </section>
 

--- a/partials/header.html
+++ b/partials/header.html
@@ -4,7 +4,7 @@
         <nav class="main-nav">
             <ul>
                 <li><a href="{{root}}/index.html#hero">Accueil</a></li>
-                <li><a href="{{root}}/index.html#about">À propos</a></li>
+                <li><a href="{{root}}/apropos.html">À propos</a></li>
                 <li><a href="{{root}}/index.html#publications">Publications</a></li>
                 <li><a href="{{root}}/articles/memoire-institutionnalisation-communs-numeriques.html">Mémoire</a></li>
                 <li><a href="{{root}}/contact.html">Contact</a></li>


### PR DESCRIPTION
The 'À propos de l'auteur' section has been moved from the landing page (`index.html`) to a new dedicated page, `apropos.html`.

Changes include:
- Creation of `apropos.html` with the content from the original 'About' section, incorporating the standard site header and footer.
- Removal of the 'About' section from `index.html`.
- Update of navigation links in `partials/header.html`, `index.html`, and `apropos.html` to reflect the new location of the 'About' page (`apropos.html`).

This change makes the landing page more focused and provides a dedicated URL for the 'About' information.