### PR TITLE
Fix: Adjust article layout for full-width display

### DIFF
--- a/style.css
+++ b/style.css
@@ -768,9 +768,13 @@ h1[id], h2[id], h3[id], h4[id] {
         display: flex;
         gap: calc(var(--spacing-unit) * 6);
         align-items: flex-start; /* Align items to the top */
+        width: 100%; /* Span full viewport width */
+        max-width: none; /* Override previous max-width */
     }
 
     .long-form-article {
+        padding-left: calc(var(--spacing-unit) * 4); /* Horizontal padding */
+        padding-right: calc(var(--spacing-unit) * 4); /* Horizontal padding */
         flex-grow: 1;
         flex-basis: 0; /* Allow it to grow and shrink */
         min-width: 0; /* Prevent overflow issues with flex children */


### PR DESCRIPTION
Implements a full-width layout for article pages on screens wider than 992px. The table of contents is positioned on the left (300px width), and the article content takes the remaining space on the right.

Changes:
- Modified `style.css` within the `@media (min-width: 992px)` query:
  - Set `width: 100%` and `max-width: none` for `.article-style-container` to make it span the full viewport width.
  - Added horizontal padding to `.long-form-article` for better readability within the full-width layout.
- The existing flexbox setup ensures the TOC and article content are displayed side-by-side without overlap.
- Layout on screens smaller than 992px remains unchanged (TOC toggled as a block).

This addresses the issue where the table of contents could overlap text and ensures better utilization of screen real estate on wider displays.