### PR TITLE
Fix TOC layout width

### DIFF
--- a/articles/memoire-institutionnalisation-communs-numeriques.html
+++ b/articles/memoire-institutionnalisation-communs-numeriques.html
@@ -44,15 +44,6 @@
     <main>
         <section class="article-page-section">
             <div class="container article-style-container">
-                <article class="long-form-article">
-                    <header class="article-header">
-                        <h1>Mémoire : Les facteurs d'institutionnalisation des communs numériques dans l'administration</h1>
-                         <p class="article-abstract">
-                            <em>Ce document est une version web du mémoire de recherche. Vous trouverez ci-dessous une table des matières pour naviguer. Une version PDF complète est disponible en téléchargement.</em>
-                        </p>
-                    </header>
-
-                    <button id="toc-toggle-button" class="toc-toggle-button" aria-expanded="false" aria-controls="table-of-contents">Table des Matières</button>
                     <nav id="table-of-contents" role="navigation" aria-label="Table des matières" class="table-of-contents">
                         <h2>Table des Matières</h2>
                         <ul class="toc-list">
@@ -158,6 +149,15 @@
                             </li>
                         </ul>
                     </nav>
+                <article class="long-form-article">
+                    <header class="article-header">
+                        <h1>Mémoire : Les facteurs d'institutionnalisation des communs numériques dans l'administration</h1>
+                         <p class="article-abstract">
+                            <em>Ce document est une version web du mémoire de recherche. Vous trouverez ci-dessous une table des matières pour naviguer. Une version PDF complète est disponible en téléchargement.</em>
+                        </p>
+                    </header>
+
+                    <button id="toc-toggle-button" class="toc-toggle-button" aria-expanded="false" aria-controls="table-of-contents">Table des Matières</button>
 
                     <section id="resume-visuel" class="interactive-overview">
                         <h2>Repères visuels sur l'institutionnalisation</h2>

--- a/style.css
+++ b/style.css
@@ -776,14 +776,16 @@ h1[id], h2[id], h3[id], h4[id] {
         padding-left: calc(var(--spacing-unit) * 4); /* Horizontal padding */
         padding-right: calc(var(--spacing-unit) * 4); /* Horizontal padding */
         flex-grow: 1;
-        flex-basis: 0; /* Allow it to grow and shrink */
+        flex-basis: 70%; /* Occupies about 70% of the container */
+        max-width: 70%;
         min-width: 0; /* Prevent overflow issues with flex children */
     }
 
     .table-of-contents {
         position: sticky;
         top: calc(var(--header-height) + var(--spacing-unit) * 4); /* Below fixed header */
-        flex-basis: 300px; /* Fixed width for TOC sidebar */
+        flex-basis: 30%; /* Sidebar takes roughly 30% of width */
+        max-width: 30%;
         flex-shrink: 0; /* Prevent sidebar from shrinking */
         order: -1; /* Place TOC on the left */
         max-height: calc(100vh - var(--header-height) - var(--spacing-unit) * 8); /* Adjust max-height for viewport */


### PR DESCRIPTION
## Summary
- make the TOC sidebar 30% width and the article 70%
- move the TOC markup outside the article so flex layout applies

## Testing
- `git status --short`