### PR TITLE
Implement sticky visual for mémoire article

### DIFF
--- a/articles/memoire-institutionnalisation-communs-numeriques.html
+++ b/articles/memoire-institutionnalisation-communs-numeriques.html
@@ -26,7 +26,7 @@
         <nav class="main-nav">
             <ul>
                 <li><a href="../index.html#hero">Accueil</a></li>
-                <li><a href="../index.html#about">À propos</a></li>
+                <li><a href="../apropos.html">À propos</a></li>
                 <li><a href="../index.html#publications">Publications</a></li>
                 <li><a href="../articles/memoire-institutionnalisation-communs-numeriques.html">Mémoire</a></li>
                 <li><a href="../contact.html">Contact</a></li>
@@ -37,6 +37,8 @@
         </button>
     </div>
 </header>
+
+
 
 
 
@@ -162,21 +164,19 @@
                     <section id="resume-visuel" class="interactive-overview">
                         <h2>Repères visuels sur l'institutionnalisation</h2>
                         <div class="scrolly-container">
-                            <div class="visual-pane" aria-hidden="true">
-                                <div class="visual active" data-step="1">Visual Placeholder 1</div>
-                                <div class="visual" data-step="2">Visual Placeholder 2</div>
-                                <div class="visual" data-step="3">Visual Placeholder 3</div>
+                            <div id="sticky-visual" class="sticky-visual">
+                                <img src="../images/article-introduction-concept.png" alt="Schéma représentant l'émergence des communs numériques">
                             </div>
                             <div class="steps">
-                                <div class="step" data-step="1">
+                                <div class="step" data-step="1" data-image="../images/article-introduction-concept.png" data-alt="Schéma représentant l'émergence des communs numériques">
                                     <div class="step-image">Step Image Placeholder 1</div>
                                     <p>Émergence des communs numériques : prise de conscience et premiers collectifs.</p>
                                 </div>
-                                <div class="step" data-step="2">
+                                <div class="step" data-step="2" data-image="../images/article-gouvernance-modeles.png" data-alt="Illustration de la structuration des communs dans les organisations">
                                     <div class="step-image">Step Image Placeholder 2</div>
                                     <p>Appropriation par les organisations : structuration et expérimentations.</p>
                                 </div>
-                                <div class="step" data-step="3">
+                                <div class="step" data-step="3" data-image="../images/memoire-institutionnalisation-structure.png" data-alt="Intégration des communs numériques dans les politiques publiques">
                                     <div class="step-image">Step Image Placeholder 3</div>
                                     <p>Pérennisation institutionnelle : intégration dans les politiques publiques.</p>
                                 </div>
@@ -1638,6 +1638,8 @@
         <p><a href="../mentions-legales.html">Mentions Légales</a> | <a href="../politique-confidentialite.html">Politique de confidentialité</a></p>
     </div>
 </footer>
+
+
 
 
 

--- a/script.js
+++ b/script.js
@@ -368,30 +368,20 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- Scrolly visuals in the mémoire page ---
     document.body.classList.add('js-enabled');
     const steps = document.querySelectorAll('.interactive-overview .step');
-    const visuals = document.querySelectorAll('.interactive-overview .visual-pane .visual');
+    const stickyVisual = document.querySelector('#sticky-visual img');
 
-    if (steps.length && visuals.length && 'IntersectionObserver' in window) {
+    if (steps.length && stickyVisual && 'IntersectionObserver' in window) {
         const observer = new IntersectionObserver(entries => {
             entries.forEach(entry => {
-                const currentStepElement = entry.target;
-                const stepIndex = currentStepElement.dataset.step;
-
                 if (entry.isIntersecting) {
-                    // Activate the visual
-                    visuals.forEach(v => {
-                        v.classList.toggle('active', v.dataset.step === stepIndex);
-                    });
-                    // Activate the step
+                    stickyVisual.src = entry.target.dataset.image;
+                    stickyVisual.alt = entry.target.dataset.alt || '';
                     steps.forEach(s => {
-                        s.classList.toggle('step-active', s.dataset.step === stepIndex);
+                        s.classList.toggle('step-active', s === entry.target);
                     });
-                } else {
-                    // Optional: Deactivate step if not intersecting,
-                    // but usually another step will become active and handle it.
-                    // currentStepElement.classList.remove('step-active');
                 }
             });
-        }, { threshold: 0.5 }); // Trigger when 50% of the step is visible
+        }, { threshold: 0.5 });
 
         steps.forEach(step => observer.observe(step));
     }

--- a/style.css
+++ b/style.css
@@ -691,27 +691,20 @@ h1[id], h2[id], h3[id], h4[id] {
     display: flex;
     gap: calc(var(--spacing-unit) * 6);
 }
-.interactive-overview .visual-pane {
+
+.sticky-visual {
     flex-basis: 40%;
     position: sticky;
-    top: calc(var(--header-height) + var(--spacing-unit) * 4);
+    top: calc(var(--header-height) + var(--spacing-unit) * 2);
     height: 40vh;
     min-height: 300px;
-}
-.interactive-overview .visual-pane .visual {
-    position: absolute;
-    inset: 0;
     display: flex;
     align-items: center;
     justify-content: center;
-    background: var(--color-neutral-light);
-    border: 1px solid var(--color-border);
-    border-radius: var(--border-radius-md);
-    opacity: 0;
-    transition: opacity 0.4s ease;
 }
-.interactive-overview .visual-pane .visual.active {
-    opacity: 1;
+.sticky-visual img {
+    max-width: 100%;
+    height: auto;
 }
 .interactive-overview .steps {
     flex-basis: 60%;
@@ -1107,16 +1100,8 @@ h1[id], h2[id], h3[id], h4[id] {
     display: flex;
     gap: calc(var(--spacing-unit) * 6);
 }
-.interactive-overview .visual-pane {
-    flex-basis: 40%;
-    position: sticky;
-    top: calc(var(--header-height) + var(--spacing-unit) * 4);
-    height: 45vh; 
-    min-height: 320px;
-    display: flex; 
-    align-items: center; 
-    justify-content: center; 
-}
+
+
 .interactive-overview .visual-pane .visual {
     position: absolute;
     inset: 0;


### PR DESCRIPTION
## Summary
- add sticky visual container to mémoire article steps
- update steps with data-image and data-alt attributes
- style `.sticky-visual` container
- simplify intersection logic to swap image as steps enter view

## Testing
- `node build.js`