### PR TITLE
Fix TOC layout on several articles

### DIFF
--- a/articles/communs-champions.html
+++ b/articles/communs-champions.html
@@ -45,16 +45,6 @@
     <main>
         <section class="article-page-section">
             <div class="container article-style-container">
-                <article class="long-form-article">
-                    <header class="article-header">
-                        <h1>Les Architectes Discrets des Communs Numériques Publics : Entre Élan Vital et Défi de Pérennisation</h1>
-                        <p class="article-meta">Par A. BERGE | Publié le 13/05/2025</p>
-                        <p class="article-abstract">
-                            <em>Au cœur des administrations, là où les rouages de l'État et des collectivités territoriales impriment leur rythme, des figures singulières émergent. Ce sont les <strong>“champions internes”</strong>, les <strong>entrepreneurs institutionnels</strong> du numérique public. Avec une détermination sans faille, ils œuvrent à l'introduction et à l'ancrage des <strong>communs numériques</strong> : logiciels libres partagés, données ouvertes accessibles à tous, plateformes collaboratives co-construites. Ces pionniers sont les véritables moteurs d'une transformation silencieuse mais profonde de l'action publique. Cependant, cette dynamique, si précieuse soit-elle, porte en elle une vulnérabilité : que se passe-t-il lorsque ces porteurs de flambeau, souvent surinvestis, quittent la scène ou s'épuisent ? Cet article plonge au cœur de ce rôle ambivalent, explorant les mécanismes de leur action, les risques inhérents à une trop forte personnalisation, et les stratégies pour bâtir des communs numériques résilients, capables de prospérer au-delà de leurs instigateurs.</em>
-                        </p>
-                    </header>
-                    <button id="toc-toggle-button" class="toc-toggle-button" aria-expanded="false" aria-controls="table-of-contents">Table des Matières</button>
-
                     <nav id="table-of-contents" role="navigation" aria-label="Table des matières" class="table-of-contents">
                         <h2>Table des Matières</h2>
                         <ul>
@@ -69,6 +59,16 @@
                             <li><a href="#bibliographie-sources">Bibliographie et sources</a></li>
                         </ul>
                     </nav>
+                <article class="long-form-article">
+                    <header class="article-header">
+                        <h1>Les Architectes Discrets des Communs Numériques Publics : Entre Élan Vital et Défi de Pérennisation</h1>
+                        <p class="article-meta">Par A. BERGE | Publié le 13/05/2025</p>
+                        <p class="article-abstract">
+                            <em>Au cœur des administrations, là où les rouages de l'État et des collectivités territoriales impriment leur rythme, des figures singulières émergent. Ce sont les <strong>“champions internes”</strong>, les <strong>entrepreneurs institutionnels</strong> du numérique public. Avec une détermination sans faille, ils œuvrent à l'introduction et à l'ancrage des <strong>communs numériques</strong> : logiciels libres partagés, données ouvertes accessibles à tous, plateformes collaboratives co-construites. Ces pionniers sont les véritables moteurs d'une transformation silencieuse mais profonde de l'action publique. Cependant, cette dynamique, si précieuse soit-elle, porte en elle une vulnérabilité : que se passe-t-il lorsque ces porteurs de flambeau, souvent surinvestis, quittent la scène ou s'épuisent ? Cet article plonge au cœur de ce rôle ambivalent, explorant les mécanismes de leur action, les risques inhérents à une trop forte personnalisation, et les stratégies pour bâtir des communs numériques résilients, capables de prospérer au-delà de leurs instigateurs.</em>
+                        </p>
+                    </header>
+                    <button id="toc-toggle-button" class="toc-toggle-button" aria-expanded="false" aria-controls="table-of-contents">Table des Matières</button>
+
 
                     <section id="batisseurs-interieur" class="article-content-section">
                         <h2>Ces Bâtisseurs de l'Intérieur : Les Entrepreneurs Institutionnels en Action</h2>

--- a/articles/gouvernance-communs-numeriques.html
+++ b/articles/gouvernance-communs-numeriques.html
@@ -45,16 +45,6 @@
     <main>
         <section class="article-page-section">
             <div class="container article-style-container">
-                <article class="long-form-article">
-                    <header class="article-header">
-                        <h1>Gouverner les communs numériques : modèles, expériences et défis</h1>
-                        <p class="article-meta">Par A. BERGE | Publié le 11/05/2025</p>
-                        <p class="article-abstract">
-                            <em>Les ressources numériques partagées, données, connaissances, logiciels, plateformes; posent la question de leur gouvernance : comment une communauté peut-elle gérer et faire durer un « commun numérique » de manière collective ? Cet article dresse un panorama des grands modèles théoriques de gouvernance partagée (polycentrisme, gouvernance distribuée, communs par conception), illustrés par des exemples concrets comme Wikipédia, OpenStreetMap, Mastodon ou des projets open source. Il met en lumière les enjeux, tensions et enseignements de ces expériences, et ouvre des pistes pour l’action publique face à ces nouvelles formes d’organisation collective.</em>
-                        </p>
-                    </header>
-                    <button id="toc-toggle-button" class="toc-toggle-button" aria-expanded="false" aria-controls="table-of-contents">Table des Matières</button>
-
                     <nav id="table-of-contents" role="navigation" aria-label="Table des matières" class="table-of-contents">
                         <h2>Table des Matières</h2>
                         <ul>
@@ -73,6 +63,16 @@
                             <li><a href="#sources-article">Bibliographie et sources</a></li>
                         </ul>
                     </nav>
+                <article class="long-form-article">
+                    <header class="article-header">
+                        <h1>Gouverner les communs numériques : modèles, expériences et défis</h1>
+                        <p class="article-meta">Par A. BERGE | Publié le 11/05/2025</p>
+                        <p class="article-abstract">
+                            <em>Les ressources numériques partagées, données, connaissances, logiciels, plateformes; posent la question de leur gouvernance : comment une communauté peut-elle gérer et faire durer un « commun numérique » de manière collective ? Cet article dresse un panorama des grands modèles théoriques de gouvernance partagée (polycentrisme, gouvernance distribuée, communs par conception), illustrés par des exemples concrets comme Wikipédia, OpenStreetMap, Mastodon ou des projets open source. Il met en lumière les enjeux, tensions et enseignements de ces expériences, et ouvre des pistes pour l’action publique face à ces nouvelles formes d’organisation collective.</em>
+                        </p>
+                    </header>
+                    <button id="toc-toggle-button" class="toc-toggle-button" aria-expanded="false" aria-controls="table-of-contents">Table des Matières</button>
+
 
                     <section id="comprehension-communs" class="article-content-section">
                         <h2>Comprendre la notion de « communs » numériques</h2>

--- a/articles/gouvernance-communs-ostrom-maintien.html
+++ b/articles/gouvernance-communs-ostrom-maintien.html
@@ -45,16 +45,6 @@
     <main>
         <section class="article-page-section">
             <div class="container article-style-container">
-                <article class="long-form-article">
-                    <header class="article-header">
-                        <h1>La gouvernance des communs numériques : principes d’Ostrom et travail de maintien institutionnel</h1>
-                        <p class="article-meta">Par A. BERGE | Publié le 16/05/2025</p>
-                        <p class="article-abstract">
-                            <em>Les communs numériques (de Wikipédia à OpenStreetMap en passant par les logiciels libres) s’appuient sur des communautés qui s’auto-organisent selon des règles de gouvernance bien établies. Inspirés par les travaux d’Elinor Ostrom sur les communs naturels, ces principes de gouvernance (définition de frontières, délibération collective, surveillance mutuelle, sanctions graduées, etc.) ne sont pas que descriptifs. Ils doivent être activement institués, négociés et appliqués par les communautés elles-mêmes. En mobilisant la théorie du travail institutionnel, la mise en œuvre de ces principes peut être lue comme un <strong>travail de maintien</strong> continu, garant de la pérennité du commun. Cet article propose une lecture croisée de ces cadres théoriques, illustrée par des exemples concrets, afin d’éclairer le fonctionnement interne des communs numériques et d’esquisser des pistes pour les soutenir.</em>
-                        </p>
-                    </header>
-                    <button id="toc-toggle-button" class="toc-toggle-button" aria-expanded="false" aria-controls="table-of-contents">Table des Matières</button>
-
                     <nav id="table-of-contents" role="navigation" aria-label="Table des matières" class="table-of-contents">
                         <h2>Table des Matières</h2>
                         <ul>
@@ -66,6 +56,16 @@
                             <li><a href="#bibliographie-article">Bibliographie et sources</a></li>
                         </ul>
                     </nav>
+                <article class="long-form-article">
+                    <header class="article-header">
+                        <h1>La gouvernance des communs numériques : principes d’Ostrom et travail de maintien institutionnel</h1>
+                        <p class="article-meta">Par A. BERGE | Publié le 16/05/2025</p>
+                        <p class="article-abstract">
+                            <em>Les communs numériques (de Wikipédia à OpenStreetMap en passant par les logiciels libres) s’appuient sur des communautés qui s’auto-organisent selon des règles de gouvernance bien établies. Inspirés par les travaux d’Elinor Ostrom sur les communs naturels, ces principes de gouvernance (définition de frontières, délibération collective, surveillance mutuelle, sanctions graduées, etc.) ne sont pas que descriptifs. Ils doivent être activement institués, négociés et appliqués par les communautés elles-mêmes. En mobilisant la théorie du travail institutionnel, la mise en œuvre de ces principes peut être lue comme un <strong>travail de maintien</strong> continu, garant de la pérennité du commun. Cet article propose une lecture croisée de ces cadres théoriques, illustrée par des exemples concrets, afin d’éclairer le fonctionnement interne des communs numériques et d’esquisser des pistes pour les soutenir.</em>
+                        </p>
+                    </header>
+                    <button id="toc-toggle-button" class="toc-toggle-button" aria-expanded="false" aria-controls="table-of-contents">Table des Matières</button>
+
 
                     <section id="forets-aux-wikis" class="article-content-section">
                         <h2>Des forêts aux wikis : adapter les principes d’Ostrom aux communs numériques</h2>

--- a/articles/institutionnalisation-communs-administration.html
+++ b/articles/institutionnalisation-communs-administration.html
@@ -42,15 +42,6 @@
     <main>
         <section class="article-page-section">
             <div class="container article-style-container">
-                <article class="long-form-article">
-                    <header class="article-header">
-                        <h1>Quand les communs numériques s’installent dans l’administration : de l’innovation à la routine</h1>
-                        <p class="article-meta">Par A. BERGE | Publié le 12 mai 2025</p> <p class="article-abstract">
-                            <em>Logiciels libres, données ouvertes, plateformes collaboratives… Ces <strong>communs numériques</strong> suscitent un vif intérêt dans les administrations publiques pour leurs promesses de souveraineté et d’innovation. Mais comment passer de l’expérimentation à l’<strong>institutionnalisation</strong> ? L’article analyse comment ces ressources partagées peuvent s’ancrer durablement dans les pratiques administratives (c'est à dire devenir légitimes, stables, routinières et « allant de soi ») malgré les freins culturels, techniques et économiques. Il explore aussi quelles conditions favorisent leur succès.</em>
-                        </p>
-                    </header>
-                    <button id="toc-toggle-button" class="toc-toggle-button" aria-expanded="false" aria-controls="table-of-contents">Table des Matières</button>
-
                     <nav id="table-of-contents" role="navigation" aria-label="Table des matières" class="table-of-contents">
                         <h2>Table des Matières</h2>
                         <ul>
@@ -62,6 +53,15 @@
                             <li><a href="#bibliographie-article">Bibliographie et sources</a></li>
                         </ul>
                     </nav>
+                <article class="long-form-article">
+                    <header class="article-header">
+                        <h1>Quand les communs numériques s’installent dans l’administration : de l’innovation à la routine</h1>
+                        <p class="article-meta">Par A. BERGE | Publié le 12 mai 2025</p> <p class="article-abstract">
+                            <em>Logiciels libres, données ouvertes, plateformes collaboratives… Ces <strong>communs numériques</strong> suscitent un vif intérêt dans les administrations publiques pour leurs promesses de souveraineté et d’innovation. Mais comment passer de l’expérimentation à l’<strong>institutionnalisation</strong> ? L’article analyse comment ces ressources partagées peuvent s’ancrer durablement dans les pratiques administratives (c'est à dire devenir légitimes, stables, routinières et « allant de soi ») malgré les freins culturels, techniques et économiques. Il explore aussi quelles conditions favorisent leur succès.</em>
+                        </p>
+                    </header>
+                    <button id="toc-toggle-button" class="toc-toggle-button" aria-expanded="false" aria-controls="table-of-contents">Table des Matières</button>
+
 
                     <section id="communs-numeriques-definition" class="article-content-section">
                         <h2>Les communs numériques : de quoi parle-t-on ?</h2>

--- a/articles/introduction-communs-numeriques.html
+++ b/articles/introduction-communs-numeriques.html
@@ -43,16 +43,6 @@
     <main>
         <section class="article-page-section">
             <div class="container article-style-container">
-                <article class="long-form-article">
-                    <header class="article-header">
-                        <h1>Communs numériques : des origines aux enjeux d’aujourd’hui</h1>
-                        <p class="article-meta">Par A. BERGE | Publié le 11/05/2025</p>
-                        <p class="article-abstract">
-                            <em>Logiciels libres, encyclopédies collaboratives, données ouvertes… Ces initiatives ont un point commun : elles s’inscrivent dans le mouvement des <strong>communs numériques</strong>. Concept né avec l’essor d’Internet, il désigne des ressources numériques créées et gérées collectivement. Cet article propose une introduction aux communs numériques, de leurs origines à leurs définitions et aux défis contemporains qu’ils soulèvent.</em>
-                        </p>
-                    </header>
-                    <button id="toc-toggle-button" class="toc-toggle-button" aria-expanded="false" aria-controls="table-of-contents">Table des Matières</button>
-
                     <nav id="table-of-contents" role="navigation" aria-label="Table des matières" class="table-of-contents">
                         <h2>Table des Matières</h2>
                         <ul>
@@ -66,6 +56,16 @@
                             <li><a href="#bibliographie-article">Bibliographie et sources</a></li>
                         </ul>
                     </nav>
+                <article class="long-form-article">
+                    <header class="article-header">
+                        <h1>Communs numériques : des origines aux enjeux d’aujourd’hui</h1>
+                        <p class="article-meta">Par A. BERGE | Publié le 11/05/2025</p>
+                        <p class="article-abstract">
+                            <em>Logiciels libres, encyclopédies collaboratives, données ouvertes… Ces initiatives ont un point commun : elles s’inscrivent dans le mouvement des <strong>communs numériques</strong>. Concept né avec l’essor d’Internet, il désigne des ressources numériques créées et gérées collectivement. Cet article propose une introduction aux communs numériques, de leurs origines à leurs définitions et aux défis contemporains qu’ils soulèvent.</em>
+                        </p>
+                    </header>
+                    <button id="toc-toggle-button" class="toc-toggle-button" aria-expanded="false" aria-controls="table-of-contents">Table des Matières</button>
+
 
                     <section id="origines" class="article-content-section">
                         <h2>Aux origines des communs : de la prairie aux données</h2>

--- a/articles/valeur-publique-ere-numerique-communs.html
+++ b/articles/valeur-publique-ere-numerique-communs.html
@@ -45,16 +45,6 @@
     <main>
         <section class="article-page-section">
             <div class="container article-style-container">
-                <article class="long-form-article">
-                    <header class="article-header">
-                        <h1>La Valeur Publique à l’Ère Numérique : Comment les Communs la Réinventent ?</h1>
-                        <p class="article-meta">Par A. BERGE | Publié le 18/09/2025</p>
-                        <p class="article-abstract">
-                            <em>À l’ère du tout-numérique, les pouvoirs publics ne peuvent plus se contenter d’évaluer leur action à l’aune de seuls indicateurs financiers ou d’efficience administrative. La notion de <strong>valeur publique</strong> émerge pour saisir ce qui fait réellement progrès pour la société. Qualité du service, impact social, équité, participation citoyenne, durabilité, transparence, autant de dimensions désormais indispensables pour juger de la performance publique. Les <strong>communs numériques</strong>, données ouvertes, logiciels libres, plateformes collaboratives…, offrent de nouveaux leviers pour concrétiser cette valeur publique multidimensionnelle. Cet article propose d’explorer comment, au-delà de la simple efficacité, l’action publique s’enrichit à l’aide des communs numériques, avec à la clé un renouvellement de la gouvernance et des politiques publiques.</em>
-                        </p>
-                    </header>
-                    <button id="toc-toggle-button" class="toc-toggle-button" aria-expanded="false" aria-controls="table-of-contents">Table des Matières</button>
-
                     <nav id="table-of-contents" role="navigation" aria-label="Table des matières" class="table-of-contents">
                         <h2>Table des Matières</h2>
                         <ul>
@@ -67,6 +57,16 @@
                             <li><a href="#bibliographie-sources-valeur-publique">Bibliographie et sources</a></li>
                         </ul>
                     </nav>
+                <article class="long-form-article">
+                    <header class="article-header">
+                        <h1>La Valeur Publique à l’Ère Numérique : Comment les Communs la Réinventent ?</h1>
+                        <p class="article-meta">Par A. BERGE | Publié le 18/09/2025</p>
+                        <p class="article-abstract">
+                            <em>À l’ère du tout-numérique, les pouvoirs publics ne peuvent plus se contenter d’évaluer leur action à l’aune de seuls indicateurs financiers ou d’efficience administrative. La notion de <strong>valeur publique</strong> émerge pour saisir ce qui fait réellement progrès pour la société. Qualité du service, impact social, équité, participation citoyenne, durabilité, transparence, autant de dimensions désormais indispensables pour juger de la performance publique. Les <strong>communs numériques</strong>, données ouvertes, logiciels libres, plateformes collaboratives…, offrent de nouveaux leviers pour concrétiser cette valeur publique multidimensionnelle. Cet article propose d’explorer comment, au-delà de la simple efficacité, l’action publique s’enrichit à l’aide des communs numériques, avec à la clé un renouvellement de la gouvernance et des politiques publiques.</em>
+                        </p>
+                    </header>
+                    <button id="toc-toggle-button" class="toc-toggle-button" aria-expanded="false" aria-controls="table-of-contents">Table des Matières</button>
+
 
                     <section id="origines-redefinition-valeur-publique" class="article-content-section">
                         <h2>Origines et redéfinition de la notion de valeur publique</h2>


### PR DESCRIPTION
## Summary
- adjust layout to place sticky table of contents to the left of article text
- update six long-form article pages to match memo-style layout

## Testing
- `git status --short`
