### PR TITLE
Fix table wrapper in memo article

### DIFF
--- a/articles/memoire-institutionnalisation-communs-numeriques.html
+++ b/articles/memoire-institutionnalisation-communs-numeriques.html
@@ -1,8 +1,3 @@
-Okay, j'ai remplacé le contenu du mémoire dans votre page HTML par le nouveau contenu que vous avez fourni.
-
-Voici la page HTML mise à jour :
-
-```html
 <!DOCTYPE html>
 <html lang="fr">
 <head>
@@ -411,7 +406,8 @@ Voici la page HTML mise à jour :
                         <p>Les principes de conception institutionnelle d'Ostrom, bien qu'initialement développés pour les ressources naturelles, fournissent un cadre robuste pour penser la gouvernance durable des communs numériques, moyennant adaptation [Linåker & Runeson, 2022]. Un aspect souvent méconnu de ces principes est leur caractère performatif : ils ne se réalisent pas spontanément ni automatiquement. Leur effectivité repose sur l'action continue des membres du commun. Ces principes (définition claire des limites, congruence des règles, participation aux décisions, surveillance, sanctions graduées, résolution des conflits, reconnaissance externe, organisation multi-niveaux) ne sont pas des caractéristiques statiques, mais des règles et des processus qui doivent être activement construits, mis en œuvre, surveillés, adaptés et défendus par la communauté.</p>
                         <p>Dans cette perspective, la mise en œuvre de ces principes peut être interprétée comme une forme de travail institutionnel de maintien [Lawrence & Suddaby, 2006]. Les auteurs identifient plusieurs formes de travail par lesquelles les acteurs soutiennent et reproduisent les institutions existantes : la création de règles ou d'entités de soutien (enabling work), la surveillance et l'application des règles (policing), la dissuasion (deterring), la valorisation des comportements conformes et la stigmatisation des écarts (valourizing and demonizing), la préservation des mythes fondateurs (mythologizing), ou encore l'intégration des normes dans les routines quotidiennes (embedding and routinizing).</p>
                         <p>Cette articulation entre les principes d'Ostrom et le travail institutionnel révèle que chaque principe appelle des pratiques concrètes de maintien. Le tableau ci-dessous illustre ces correspondances, enrichies d'exemples issus de communs numériques emblématiques :</p>
-                        <table>
+                        <div class="table-responsive-wrapper">
+                        <table class="styled-table">
                             <thead>
                                 <tr>
                                     <th><strong>Principe d'Ostrom</strong></th>
@@ -462,6 +458,7 @@ Voici la page HTML mise à jour :
                                 </tr>
                             </tbody>
                         </table>
+                        </div>
                         <p>Cette grille de lecture révèle que la gouvernance interne d'un commun numérique n'est pas une simple structure administrative, mais un processus continu de travail institutionnel. Prenons l'exemple de Wikipédia : définir et faire respecter les frontières du commun implique un effort permanent pour préciser qui a le droit de contribuer, comment on devient membre, quels contenus sont acceptables. Cela s'apparente à un travail d'ajustement structurel (enabling/structuring) permanent. De même, instaurer des arènes de décision collective n'est pas qu'une question de règle formelle : il faut animer ces espaces délibératifs, former les participants aux procédures, et parfois inventer de nouvelles instances lorsque la complexité augmente.</p>
                         <p>La surveillance mutuelle et les sanctions graduées offrent un autre exemple éclairant de ce travail de maintien. Dans un commun numérique comme OpenStreetMap, surveiller les contributions mobilise des pairs volontaires, des bots informatiques, des modérateurs élus - un véritable système socio-technique à mettre en place et à affiner en permanence. Il faut non seulement détecter les écarts, mais aussi décider de la réponse appropriée, appliquer des sanctions de façon juste et proportionnée, et expliquer ces décisions pour qu'elles soient comprises et acceptées. Ce travail de "police communautaire" (policing) est crucial pour maintenir la confiance et la coopération à long terme.</p>
                         <p>Un volet moins visible mais tout aussi important est le travail de légitimation normative. Les communautés valorisent certains comportements exemplaires (via des récompenses symboliques comme les barnstars de Wikipédia) et stigmatisent les conduites contraires. La mise en récit de l'histoire du projet, de ses victoires et moments fondateurs, agit comme un ciment identitaire (mythologizing). Dans Wikipédia, les "cinq piliers" fondateurs sont fréquemment évoqués comme une mythologie partagée, tandis que les projets libres valorisent des figures héroïques qui incarnent la raison d'être du commun.</p>


### PR DESCRIPTION
## Summary
- clean up leftover HTML at top of memo article
- wrap the Ostrom/TTI table in a responsive `<div>` like the governance article

## Testing
- `git status --short`