### PR TITLE
Add placeholder for upcoming PDF

### DIFF
--- a/articles/memoire-institutionnalisation-communs-numeriques.html
+++ b/articles/memoire-institutionnalisation-communs-numeriques.html
@@ -1293,7 +1293,7 @@
                         <h3>Version complète (PDF) :</h3>
                         <p>
                             Pour une lecture approfondie, l'intégralité des références et les annexes, vous pouvez télécharger la version PDF du mémoire :
-                            <a href="../memoire/memoire-berge-alexandre-communs-numeriques.pdf" download="Memoire_Communs_Numeriques_BERGE_Alexandre.pdf" class="cta-button-secondary">
+                            <a href="../memoire/prochainement.html" class="cta-button-secondary">
                                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="margin-right: 6px; vertical-align: text-bottom;"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
                                 Télécharger le mémoire (PDF)
                             </a>

--- a/memoire/prochainement.html
+++ b/memoire/prochainement.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PDF prochainement disponible - Communs Numériques</title>
+    <meta name="description" content="Le PDF du mémoire sera bientôt disponible." />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;900&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../style.css">
+    <link rel="icon" href="../images/favicon.ico" type="image/x-icon">
+    <link rel="apple-touch-icon" href="../images/apple-touch-icon.png">
+</head>
+<body>
+    <div id="reading-progress"></div>
+    <header id="main-header">
+    <div class="container">
+        <a href="../index.html#hero" class="logo">Communs Numériques</a>
+        <nav class="main-nav">
+            <ul>
+                <li><a href="../index.html#hero">Accueil</a></li>
+                <li><a href="../apropos.html">À propos</a></li>
+                <li><a href="../index.html#publications">Publications</a></li>
+                <li><a href="../articles/memoire-institutionnalisation-communs-numeriques.html">Mémoire</a></li>
+                <li><a href="../contact.html">Contact</a></li>
+            </ul>
+        </nav>
+        <button class="nav-toggle" aria-label="Ouvrir le menu" aria-expanded="false">
+            <span class="hamburger"></span>
+        </button>
+    </div>
+</header>
+
+    <main class="container" style="padding-top: 120px; text-align: center;">
+        <h1>Prochainement disponible</h1>
+        <p>Le PDF du mémoire n'est pas encore disponible.</p>
+        <p><a href="../index.html">Retour à l'accueil</a></p>
+    </main>
+    <footer id="main-footer">
+    <div class="container">
+        <p>© <span id="current-year"></span> Alexandre BERGE. Contenu sous licence <a href="https://creativecommons.org/licenses/by-sa/4.0/deed.fr" target="_blank" rel="noopener noreferrer">CC BY-SA 4.0</a>.</p>
+        <p><a href="../mentions-legales.html">Mentions Légales</a> | <a href="../politique-confidentialite.html">Politique de confidentialité</a></p>
+    </div>
+</footer>
+
+    <button id="back-to-top" aria-label="Retour en haut">↑</button>
+    <script src="../script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a page that informs users the PDF will be available soon
- update the memory article link to point to the new placeholder page

## Testing
- `node build.js` *(fails: modifies repo, reverted)*