### PR TITLE
Fix publications navigation link

### DIFF
--- a/partials/header.html
+++ b/partials/header.html
@@ -5,7 +5,7 @@
             <ul>
                 <li><a href="{{root}}/index.html#hero">Accueil</a></li>
                 <li><a href="{{root}}/apropos.html">À propos</a></li>
-                <li><a href="{{root}}/index.html#publications">Publications</a></li>
+                <li><a href="{{root}}/articles/index.html">Publications</a></li>
                 <li><a href="{{root}}/articles/memoire-institutionnalisation-communs-numeriques.html">Mémoire</a></li>
                 <li><a href="{{root}}/contact.html">Contact</a></li>
             </ul>

--- a/script.js
+++ b/script.js
@@ -164,10 +164,11 @@ document.addEventListener('DOMContentLoaded', () => {
         window.addEventListener('scroll', changeActiveLink);
         window.addEventListener('load', changeActiveLink); // Aussi au chargement
     } else {
-        // Pour les autres pages, juste matcher le lien exact
+        // Pour les autres pages, matcher le chemin ou le dossier articles
          navLinks.forEach(link => {
             const linkPath = new URL(link.href, window.location.origin).pathname;
-            if (linkPath === window.location.pathname) {
+            const isArticlesLink = linkPath === '/articles/index.html' && window.location.pathname.startsWith('/articles/');
+            if (linkPath === window.location.pathname || isArticlesLink) {
                 link.classList.add('active');
             } else {
                 link.classList.remove('active');


### PR DESCRIPTION
## Summary
- update the header to link directly to `/articles/index.html`
- mark the publication nav item active when visiting any `/articles/` page

## Testing
- `npm test` *(fails: could not find package.json)*