### PR TITLE
Refine publications layout

### DIFF
--- a/articles/index.html
+++ b/articles/index.html
@@ -51,69 +51,65 @@
         </section>
         <section class="article-page-section">
             <div class="container article-style-container">
-                <h2>Publications</h2>
-                <p class="text-center" style="margin-top: calc(var(--spacing-unit) * 2);">
-                    Retrouvez ici l'ensemble des articles et recherches publiés sur les communs numériques.
-                </p>
                 <div class="recent-articles-list animate-on-scroll fade-in-up">
-                    <div class="article-grid">
-                        <article class="article-card animate-on-scroll fade-in-up delay-1">
+                    <ul>
+                        <li class="animate-on-scroll fade-in-up delay-1">
                             <a href="introduction-communs-numeriques.html">
-                                <img src="../images/article-introduction-concept.png" alt="Illustration introduction aux communs numériques" loading="lazy">
-                                <h3 class="article-card-title">Introduction aux Communs Numériques</h3>
-                                <p class="article-card-description">Définitions, exemples et enjeux clés.</p>
+                                <span class="article-item-title">Introduction aux Communs Numériques</span>
+                                <span class="article-item-description">Définitions, exemples et enjeux clés.</span>
+                                <span class="article-item-arrow">→</span>
                             </a>
-                        </article>
-                        <article class="article-card animate-on-scroll fade-in-up delay-2">
+                        </li>
+                        <li class="animate-on-scroll fade-in-up delay-2">
                             <a href="gouvernance-communs-numeriques.html">
-                                <img src="../images/article-gouvernance-modeles.png" alt="Illustration gouvernance des communs numériques" loading="lazy">
-                                <h3 class="article-card-title">La Gouvernance des Communs : Modèles et Défis</h3>
-                                <p class="article-card-description">Un tour d'horizon des approches de gestion collective.</p>
+                                <span class="article-item-title">La Gouvernance des Communs : Modèles et Défis</span>
+                                <span class="article-item-description">Un tour d'horizon des approches de gestion collective.</span>
+                                <span class="article-item-arrow">→</span>
                             </a>
-                        </article>
-                        <article class="article-card animate-on-scroll fade-in-up delay-3">
+                        </li>
+                        <li class="animate-on-scroll fade-in-up delay-3">
                             <a href="institutionnalisation-communs-administration.html">
-                                <img src="../images/memoire-institutionnalisation-structure.png" alt="Illustration institutionnalisation des communs numériques" loading="lazy">
-                                <h3 class="article-card-title">Les facteurs d'institutionnalisation des communs numériques</h3>
-                                <p class="article-card-description">Concepts théoriques et cas emblématiques.</p>
+                                <span class="article-item-title">Les facteurs d'institutionnalisation des communs numériques</span>
+                                <span class="article-item-description">Concepts théoriques et cas emblématiques.</span>
+                                <span class="article-item-arrow">→</span>
                             </a>
-                        </article>
-                        <article class="article-card animate-on-scroll fade-in-up delay-4">
+                        </li>
+                        <li class="animate-on-scroll fade-in-up delay-4">
                             <a href="communs-champions.html">
-                                <img src="../images/berge-a-profil.png" alt="Illustration architectes des communs numériques publics" loading="lazy">
-                                <h3 class="article-card-title">Les Architectes Discrets des Communs Numériques Publics</h3>
-                                <p class="article-card-description">Entrepreneurs institutionnels, leur rôle, apports et limites.</p>
+                                <span class="article-item-title">Les Architectes Discrets des Communs Numériques Publics</span>
+                                <span class="article-item-description">Entrepreneurs institutionnels, leur rôle, apports et limites.</span>
+                                <span class="article-item-arrow">→</span>
                             </a>
-                        </article>
-                        <article class="article-card animate-on-scroll fade-in-up delay-5">
+                        </li>
+                        <li class="animate-on-scroll fade-in-up delay-5">
                             <a href="gouvernance-communs-ostrom-maintien.html">
-                                <img src="../images/article-gouvernance-modeles.png" alt="Illustration principes d'Ostrom" loading="lazy">
-                                <h3 class="article-card-title">Principes d’Ostrom et travail de maintien institutionnel</h3>
-                                <p class="article-card-description">Principes d'Ostrom et travail de maintien institutionnel.</p>
+                                <span class="article-item-title">Principes d’Ostrom et travail de maintien institutionnel</span>
+                                <span class="article-item-description">Principes d'Ostrom et travail de maintien institutionnel.</span>
+                                <span class="article-item-arrow">→</span>
                             </a>
-                        </article>
-                        <article class="article-card animate-on-scroll fade-in-up delay-6">
+                        </li>
+                        <li class="animate-on-scroll fade-in-up delay-6">
                             <a href="valeur-publique-ere-numerique-communs.html">
-                                <img src="../images/article-valeur-publique-communs.png" alt="Illustration valeur publique à l'ère numérique" loading="lazy">
-                                <h3 class="article-card-title">La Valeur Publique à l’Ère Numérique</h3>
-                                <p class="article-card-description">La notion de valeur publique enrichit par les communs numériques.</p>
+                                <span class="article-item-title">La Valeur Publique à l’Ère Numérique</span>
+                                <span class="article-item-description">La notion de valeur publique enrichit par les communs numériques.</span>
+                                <span class="article-item-arrow">→</span>
                             </a>
-                        </article>
-                        <article class="article-card animate-on-scroll fade-in-up delay-7">
+                        </li>
+                        <li class="animate-on-scroll fade-in-up delay-7">
                             <a href="npm_deg.html">
-                                <img src="../images/article-npm-gouvernance-ere-numerique-communs.png" alt="Illustration New Public Management et gouvernance numérique" loading="lazy">
-                                <h3 class="article-card-title">Du New Public Management à la Gouvernance à l’Ère Numérique</h3>
-                                <p class="article-card-description">Comment les communs numériques se confrontent à la doctrine du NPM?</p>
+                                <span class="article-item-title">Du New Public Management à la Gouvernance à l’Ère Numérique</span>
+                                <span class="article-item-description">Comment les communs numériques se confrontent à la doctrine du NPM?</span>
+                                <span class="article-item-arrow">→</span>
                             </a>
-                        </article>
-                        <article class="article-card animate-on-scroll fade-in-up delay-8">
+                        </li>
+                        <li class="animate-on-scroll fade-in-up delay-8">
                             <a href="memoire-institutionnalisation-communs-numeriques.html">
-                                <img src="../images/memoire-institutionnalisation-structure.png" alt="Illustration mémoire de recherche sur l'institutionnalisation des communs numériques" loading="lazy">
-                                <h3 class="article-card-title">Mémoire de recherche</h3>
-                                <p class="article-card-description">Les facteurs d'institutionnalisation des communs numériques dans l'administration.</p>
+                                <span class="article-item-title">Mémoire de recherche</span>
+                                <span class="article-item-description">Les facteurs d'institutionnalisation des communs numériques dans l'administration.</span>
+                                <span class="article-item-arrow">→</span>
                             </a>
-                        </article>
-                    </div>
+                        </li>
+                    </ul>
                 </div>
             </div>
         </section>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,6 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://alexandre-berge.fr/404.html</loc></url>
   <url><loc>https://alexandre-berge.fr/apropos.html</loc></url>
+  <url><loc>https://alexandre-berge.fr/articles/NPM_DEG.html</loc></url>
   <url><loc>https://alexandre-berge.fr/articles/communs-champions.html</loc></url>
   <url><loc>https://alexandre-berge.fr/articles/gouvernance-communs-numeriques.html</loc></url>
   <url><loc>https://alexandre-berge.fr/articles/gouvernance-communs-ostrom-maintien.html</loc></url>
@@ -12,6 +13,7 @@
   <url><loc>https://alexandre-berge.fr/articles/valeur-publique-ere-numerique-communs.html</loc></url>
   <url><loc>https://alexandre-berge.fr/contact.html</loc></url>
   <url><loc>https://alexandre-berge.fr/index.html</loc></url>
+  <url><loc>https://alexandre-berge.fr/memoire/prochainement.html</loc></url>
   <url><loc>https://alexandre-berge.fr/mentions-legales.html</loc></url>
   <url><loc>https://alexandre-berge.fr/politique-confidentialite.html</loc></url>
 </urlset>

--- a/style.css
+++ b/style.css
@@ -284,6 +284,13 @@ main > section { padding: calc(var(--spacing-unit) * 12) 0; }
     margin-top: calc(var(--spacing-unit) * 10);
 }
 
+/* Center article links on publications page */
+.article-page-section .recent-articles-list {
+    width: 80%;
+    margin-left: auto;
+    margin-right: auto;
+}
+
 .recent-articles-title {
     font-size: 1.25rem;
     font-weight: 600;


### PR DESCRIPTION
## Summary
- remove redundant section heading on `articles/` index
- center article links and limit to 80% width
- update sitemap

## Testing
- `node generate-sitemap.js`